### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Ww
-version=0.01
+version=0.1
 author=Andrew Rapo, WorthwhileGames
 maintainer=WorthwhileGames <www.WorthwhileGames.org>
 sentence= Used to drive all WorthwhileGames arduino projects.


### PR DESCRIPTION
The previous `version` value caused the Arduino IDE to display warnings:
```
Invalid version found: 0.01
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format